### PR TITLE
Rename `woodpecker_ci_agent_systemd_required_systemd_services_list_*`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,10 +37,10 @@ woodpecker_ci_agent_container_additional_networks_auto: []
 woodpecker_ci_agent_container_additional_networks_custom: []
 
 # List of systemd services that the Woodpecker CI Agent systemd service depends on
-woodpecker_ci_agent_systemd_required_systemd_services_list: "{{ woodpecker_ci_agent_systemd_required_systemd_services_list_default + woodpecker_ci_agent_systemd_required_systemd_services_list_auto + woodpecker_ci_agent_systemd_required_systemd_services_list_custom }}"
-woodpecker_ci_agent_systemd_required_systemd_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
-woodpecker_ci_agent_systemd_required_systemd_services_list_auto: []
-woodpecker_ci_agent_systemd_required_systemd_services_list_custom: []
+woodpecker_ci_agent_systemd_required_services_list: "{{ woodpecker_ci_agent_systemd_required_services_list_default + woodpecker_ci_agent_systemd_required_services_list_auto + woodpecker_ci_agent_systemd_required_services_list_custom }}"
+woodpecker_ci_agent_systemd_required_services_list_default: "{{ [devture_systemd_docker_base_docker_service_name] if devture_systemd_docker_base_docker_service_name else [] }}"
+woodpecker_ci_agent_systemd_required_services_list_auto: []
+woodpecker_ci_agent_systemd_required_services_list_custom: []
 
 # List of systemd services that the Woodpecker CI Agent systemd service wants
 woodpecker_ci_agent_systemd_wanted_services_list: []

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -1,8 +1,20 @@
-# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 ---
+
+- name: (Deprecation) Catch and report renamed settings
+  ansible.builtin.fail:
+    msg: >-
+      Your configuration contains a variable, which now has a different name.
+      Please change your configuration to rename the variable (`{{ item.old }}` -> `{{ item.new }}`).
+  when: "item.old in vars"
+  with_items:
+    - {'old': 'woodpecker_ci_agent_systemd_required_systemd_services_list', 'new': 'woodpecker_ci_agent_systemd_required_services_list'}
+    - {'old': 'woodpecker_ci_agent_systemd_required_systemd_services_list_default', 'new': 'woodpecker_ci_agent_systemd_required_services_list_default'}
+    - {'old': 'woodpecker_ci_agent_systemd_required_systemd_services_list_auto', 'new': 'woodpecker_ci_agent_systemd_required_services_list_auto'}
+    - {'old': 'woodpecker_ci_agent_systemd_required_systemd_services_list_custom', 'new': 'woodpecker_ci_agent_systemd_required_services_list_custom'}
 
 - name: Fail if required Woodpecker CI server settings not defined
   ansible.builtin.fail:

--- a/templates/systemd/woodpecker-ci-agent.service.j2
+++ b/templates/systemd/woodpecker-ci-agent.service.j2
@@ -8,7 +8,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 [Unit]
 Description=Woodpecker CI Agent
-{% for service in woodpecker_ci_agent_systemd_required_systemd_services_list %}
+{% for service in woodpecker_ci_agent_systemd_required_services_list %}
 Requires={{ service }}
 After={{ service }}
 {% endfor %}


### PR DESCRIPTION
Reuse https://github.com/mother-of-all-self-hosting/ansible-role-vaultwarden/blob/219e939cd4c5965a8022eaccd52c862925ccd8e7/tasks/validate_config.yml.